### PR TITLE
feat(crypto): create Buffer via Buffer.from, because constructor is deprecated in current node

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,25 @@ const randomData = [
     crypto.randomBytes(1024).toString('hex')
 ];
 
-async function exmaple(password, data) {
+async function example(password, data) {
     const salt = await ecrypto.generateSalt();
     const key = await ecrypto.generateKey(password, salt);
-    const encrypted = await randomData.map(data => ecrypto.encryptWithKey(key, data));
+    const encrypted = await Promise.all(
+        data.map(item => ecrypto.encryptWithKey(key, item))
+    );
 
     const saltFromEncrypted = ecrypto.getSaltFromEncrypted(encrypted[0]);
     const keyForDecryption = await ecrypto.generateKey(password, saltFromEncrypted);
-    const decrypted = await encrypted.map(data => ecrypto.decryptWithKey(key, data));
-    randomData === decrypted; //true
+    const decrypted = await Promise.all(
+        encrypted.map(item => ecrypto.decryptWithKey(keyForDecryption, item))
+    );
+    
+    return data.reduce((allValid, item, index) => {
+        return allValid && item === decrypted[index];
+    }, true);
 }
+
+example(password, randomData);
 
 ```
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -72,7 +72,7 @@ class Crypto {
   }
 
   getSaltFromEncrypted(encrypted) {
-    const cipherText = new Buffer(encrypted, CIPHERTEXT_ENCODING);
+    const cipherText = Buffer.from(encrypted, CIPHERTEXT_ENCODING);
     return cipherText.slice(0, this._passwordSaltSize);
   }
 
@@ -95,7 +95,7 @@ class Crypto {
   }
 
   _buildDecryptParameters(key, ciphertext) {
-    const rawCiphertext = new Buffer(ciphertext, CIPHERTEXT_ENCODING);
+    const rawCiphertext = Buffer.from(ciphertext, CIPHERTEXT_ENCODING);
     const slicedRawData = this._sliceCiphertext(rawCiphertext);
     return this._createDecryptKeyObject(slicedRawData, key.key);
   }
@@ -127,7 +127,7 @@ class Crypto {
   _createEncryptKeyObject(plaintext, iv, keyAndSalt) {
     const salt = keyAndSalt.salt;
     const key = keyAndSalt.key;
-    const rawPlaintext = new Buffer(plaintext, PLAINTEXT_ENCODING);
+    const rawPlaintext = Buffer.from(plaintext, PLAINTEXT_ENCODING);
     return { iv, salt, rawPlaintext, key };
   }
 
@@ -182,7 +182,7 @@ class Crypto {
   }
 
   _validateSaltSize(salt) {
-    if(new Buffer(salt, CIPHERTEXT_ENCODING).length !== this._passwordSaltSize) {
+    if(Buffer.from(salt, CIPHERTEXT_ENCODING).length !== this._passwordSaltSize) {
       throw new Error('Salt length must be ' + this._passwordSaltSize + '.');
     }
   }

--- a/lib/crypto.spec.js
+++ b/lib/crypto.spec.js
@@ -82,7 +82,7 @@ describe('Crypto', function() {
     it('should correctly prefix ciphertext with password salt and iv', function* () {
       stubRandomBytes.call(this, ['AAAAAAAAAAAA', 'BBBBBBBBBBBB']);
 
-      const encrypted = new Buffer(yield defaultInstance.encrypt('pw', 'data'), 'base64');
+      const encrypted = Buffer.from(yield defaultInstance.encrypt('pw', 'data'), 'base64');
 
       expect(encrypted.slice(0, 12).toString('utf-8')).to.eql('AAAAAAAAAAAA');
       expect(encrypted.slice(12, 24).toString('utf-8')).to.eql('BBBBBBBBBBBB');
@@ -148,7 +148,7 @@ describe('Crypto', function() {
     });
 
     function tamperWithCiphertext(ciphertext, index) {
-      const rawCiphertext = new Buffer(ciphertext, 'base64');
+      const rawCiphertext = Buffer.from(ciphertext, 'base64');
       rawCiphertext[index] = rawCiphertext[index] === 0x01 ? 0x02 : 0x01;
       return rawCiphertext.toString('base64');
     }
@@ -159,7 +159,7 @@ describe('Crypto', function() {
 
     it('should return the salt from cipherText', function () {
       let expectedSalt = 'A'.repeat(12);
-      const encrypted = new Buffer(expectedSalt + '123456').toString('base64');
+      const encrypted = Buffer.from(expectedSalt + '123456').toString('base64');
       const actualSalt = defaultInstance.getSaltFromEncrypted(encrypted);
 
       expect(actualSalt.toString('utf-8')).to.eql(expectedSalt);
@@ -179,13 +179,13 @@ describe('Crypto', function() {
     });
 
     it('should return a Promise', function* () {
-      const salt = new Buffer('A'.repeat(12));
+      const salt = Buffer.from('A'.repeat(12));
       const key = defaultInstance.generateKey('123456', salt);
       expect(key).to.be.instanceOf(Promise);
     });
 
     it('should resolve to a Key', function* () {
-      const salt = new Buffer('A'.repeat(12));
+      const salt = Buffer.from('A'.repeat(12));
       const key = yield defaultInstance.generateKey('123456', salt);
       expect(key).to.be.instanceOf(Key);
     });
@@ -203,7 +203,7 @@ describe('Crypto', function() {
     });
 
     it('should throw an error if the salt length is not correct', function* () {
-      const salt = new Buffer('A'.repeat(10));
+      const salt = Buffer.from('A'.repeat(10));
 
       let expectedError;
       try {
@@ -217,7 +217,7 @@ describe('Crypto', function() {
     });
 
     it('should throw an error if the salt length is not correct', function* () {
-      const salt = new Buffer('A'.repeat(12));
+      const salt = Buffer.from('A'.repeat(12));
       const password = '123456';
       const pbkdf2Spy = this.sandbox.spy(crypto, 'pbkdf2');
 
@@ -244,7 +244,7 @@ describe('Crypto', function() {
       stubRandomBytes.call(this, ['AAAAAAAAAAAA']);
       const salt = yield defaultInstance.generateSalt();
 
-      expect(salt).to.eql(new Buffer('AAAAAAAAAAAA', 'utf-8'));
+      expect(salt).to.eql(Buffer.from('AAAAAAAAAAAA', 'utf-8'));
     });
 
   });
@@ -313,13 +313,13 @@ describe('Crypto', function() {
       yield plaintext;
     });
 
-  })
+  });
 
   function stubRandomBytes(randomBytes) {
     let counter = 0;
     this.sandbox.stub(crypto, 'randomBytes', function(length, cb) {
       expect(length).to.eql(12);
-      const randomBuffer = new Buffer(randomBytes[counter], 'utf-8');
+      const randomBuffer = Buffer.from(randomBytes[counter], 'utf-8');
       counter++;
       return cb(null, randomBuffer);
     });


### PR DESCRIPTION
This contains a fix to be able to use the package in node 10 and above, because of the Buffer constructor deprecation. The change is to use `Buffer.from` instead of the constructor.
This pull request should be a breaking change if it support node version before 5.10, [`Buffer.from` introduced in this version](https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_class_method_buffer_from_array).